### PR TITLE
Downgrade minSdk 24

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -8,7 +8,7 @@ object Config {
     const val debug = "debug"
 
     object Android {
-        const val minSdk = 25
+        const val minSdk = 24
         const val targetSdk = 32
         const val compileSdk = targetSdk
         const val instrumentedTestRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/config/deps.versions.toml
+++ b/config/deps.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradle = "7.3.0-beta04"
+androidGradle = "7.3.0"
 kotlin = "1.7.10"
 coroutines = "1.6.4"
 dateTime = "0.4.0"


### PR DESCRIPTION
We need to use with minSdk 24.

KMM required minSdk 21 or later?
I could not find out KMM requirement minSdk clearly.

![image](https://user-images.githubusercontent.com/5770480/195472430-b5ab14a7-05b2-48f6-97e9-eb12f0589b2a.png)


https://kotlinlang.org/docs/multiplatform-mobile-create-first-app.html#create-the-project-from-a-template

https://github.com/Kotlin/kmm-basic-sample/blob/30dbf7dde7626ff77194a509fc1062c945ecc73b/shared/build.gradle.kts#L59

included #1 

Clean & Rebuild Succeeded after changed on Android Studio Dolphin | 2021.3.1 .
https://developer.android.com/studio/releases